### PR TITLE
prompts and plugin installation process

### DIFF
--- a/Genoo.php
+++ b/Genoo.php
@@ -5,7 +5,7 @@
     Author:  Genoo, LLC
     Author URI: http://www.genoo.com/
     Author Email: info@genoo.com
-    Version: 6.0.5
+    Version: 6.0.6
     License: GPLv2
     Text Domain: genoo
 */

--- a/libs/WPME/Extensions/Clever/Plugins.php
+++ b/libs/WPME/Extensions/Clever/Plugins.php
@@ -73,7 +73,7 @@ class Plugins
                 jQuery(function() {
                     // On install
                     jQuery(document).on('wp-plugin-install-success', function(event, data){
-                        if (data.slug.indexOf("wpmktgengine") !== -1) {
+                        
                             // Get container
                             var url = ajaxurl.replace(/[^\/]*$/, '');
                             var append = jQuery('.wpme-plugin-notice.plugin-card-' + data.slug);
@@ -87,7 +87,6 @@ class Plugins
                                     .attr('href', '')
                                     .removeClass('thickbox')
                                     .removeClass('open-plugin-details-modal');
-                        }
                         return;
                     });
                 });

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.6
 Tested up to: 5.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Stable tag: 6.0.5
+Stable tag: 6.0.6
 
 Combine the flexibility of WordPress with the power of Genoo and experience amazing results!
 


### PR DESCRIPTION
1)Fixed issue - while activating the plugin its prompts popup instead of getting activated.
2)Removed index of data-slug condition because some of our plugins data-slug did not contain the word "wpmktgengine".